### PR TITLE
Hotfix: postDate Invalid datetime format error

### DIFF
--- a/src/services/EntriesContent.php
+++ b/src/services/EntriesContent.php
@@ -140,7 +140,7 @@ class EntriesContent extends BaseContentMigration
         }
 
         $entry->slug = $data['slug'];
-        $entry->postDate = DateTimeHelper::toDateTime($data['postDate']['date']);
+        $entry->postDate = is_null($data['postDate']) ? '' : DateTimeHelper::toDateTime($data['postDate']['date']);
         $entry->expiryDate = is_null($data['expiryDate']) ? '' : DateTimeHelper::toDateTime($data['expiryDate']['date']);
         $entry->enabled = $data['enabled'];
         $entry->siteId = Craft::$app->sites->getSiteByHandle($data['site'])->id;


### PR DESCRIPTION
Hotfix for mysql error when postDate is not set on an entry

Fixes below error
```
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '' for column `project`.`craft_entries`.`postDate`
```