### PR TITLE
Cleanup user-permissions and use site handles

### DIFF
--- a/src/helpers/MigrationManagerHelper.php
+++ b/src/helpers/MigrationManagerHelper.php
@@ -224,7 +224,7 @@ class MigrationManagerHelper
                     $element = Craft::$app->categories->getGroupByHandle($permissionParts[1]);
                 } elseif (preg_match('/globalset/', $permissionParts[0])) {
                     $element = Craft::$app->globals->getSetByHandle($permissionParts[1]);
-                } elseif (preg_match('/sites/', $permissionParts[0])) {
+                } elseif (preg_match('/site/', $permissionParts[0])) {
                     $element = Craft::$app->sites->getSiteByHandle($permissionParts[1]);
                 }
 

--- a/src/helpers/MigrationManagerHelper.php
+++ b/src/helpers/MigrationManagerHelper.php
@@ -224,6 +224,8 @@ class MigrationManagerHelper
                     $element = Craft::$app->categories->getGroupByHandle($permissionParts[1]);
                 } elseif (preg_match('/globalset/', $permissionParts[0])) {
                     $element = Craft::$app->globals->getSetByHandle($permissionParts[1]);
+                } elseif (preg_match('/sites/', $permissionParts[0])) {
+                    $element = Craft::$app->sites->getSiteByHandle($permissionParts[1]);
                 }
 
                 if ($element != null) {
@@ -257,6 +259,8 @@ class MigrationManagerHelper
                     $element = $hasUids ? Craft::$app->categories->getGroupByUid($permissionParts[1]) : Craft::$app->categories->getGroupById($permissionParts[1]);
                 } elseif (preg_match('/globalset/', $permissionParts[0])) {
                     $element = $hasUids ? MigrationManagerHelper::getGlobalSetByUid($permissionParts[1]) : Craft::$app->globals->getSetByid($permissionParts[1]);
+                } elseif (preg_match('/sites/', $permissionParts[0])) {
+                    $element = $hasUids ? Craft::$app->sites->getSiteByUid($permissionParts[1]) : Craft::$app->sites->getSiteById($permissionParts[1]);
                 }
 
                 if ($element != null) {

--- a/src/helpers/MigrationManagerHelper.php
+++ b/src/helpers/MigrationManagerHelper.php
@@ -259,7 +259,7 @@ class MigrationManagerHelper
                     $element = $hasUids ? Craft::$app->categories->getGroupByUid($permissionParts[1]) : Craft::$app->categories->getGroupById($permissionParts[1]);
                 } elseif (preg_match('/globalset/', $permissionParts[0])) {
                     $element = $hasUids ? MigrationManagerHelper::getGlobalSetByUid($permissionParts[1]) : Craft::$app->globals->getSetByid($permissionParts[1]);
-                } elseif (preg_match('/sites/', $permissionParts[0])) {
+                } elseif (preg_match('/site/', $permissionParts[0])) {
                     $element = $hasUids ? Craft::$app->sites->getSiteByUid($permissionParts[1]) : Craft::$app->sites->getSiteById($permissionParts[1]);
                 }
 

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -705,7 +705,7 @@ class Fields extends BaseMigration
                 {
                     $type = $newSource->type == "single" ? "single" : "section";
 
-					$newSources[] = $type.':' . (MigrationManagerHelper::isVersion('3.1') ? $newSource->uid : $newSource->id);
+                    $newSources[] = $type.':' . (MigrationManagerHelper::isVersion('3.1') ? $newSource->uid : $newSource->id);
                 }
                 elseif ($source == 'singles')
                 {

--- a/src/services/UserGroups.php
+++ b/src/services/UserGroups.php
@@ -44,6 +44,7 @@ class UserGroups extends BaseMigration
 
             $newGroup['permissions'] = $this->getGroupPermissionHandles($id);
             $newGroup['settings'] = Craft::$app->systemSettings->getSettings('users');
+            unset($newGroup['settings']['groups']);
 
             if ($newGroup['settings']['defaultGroup'] != null) {
                 if (MigrationManagerHelper::isVersion('3.1')) {


### PR DESCRIPTION
User permissions contained unneeded nesting of groups. Sites where using the uid instead of the handle.