### PR TITLE
bugfix: error when exporting entries with LinkFields referencing an entry that does not exist on the default site

### DIFF
--- a/src/services/BaseContentMigration.php
+++ b/src/services/BaseContentMigration.php
@@ -100,7 +100,7 @@ abstract class BaseContentMigration extends BaseMigration
                 if (in_array($value->type, $elementTypes)){
                     $elementType = 'craft\\elements\\' . ucfirst($value->type);
                     if ($value->value != null){
-                      $element = Craft::$app->elements->getElementById($value->value, $elementType);
+                      $element = Craft::$app->elements->getElementById($value->value, $elementType, ($parent && $parent->siteId ? $parent->siteId : null));
                       $value->value = [$this->getSourceHandle($element, $elementType)];
                     }
                 } elseif ($value->type == 'site'){


### PR DESCRIPTION
To replicate the issue:

- Create a multisite Craft install & install migration assistant
- Create a secondary site
- Create a section with Propagation Method set to "Let each entry choose which sites it should be saved to" and add it to your secondary site (make sure the entry type includes a LinkField)
- Create two entries in your new section, make sure one of them links to the other one and each entry is _only_ enabled on the secondary site
- Attempt to create a migration for the entry with the populated LinkField

Expected outcome: A migration is successfully created
Actual outcome: 500 error, processing fails at line 337 of `BaseContentMigration::getSourceHandle()` due to `$element` being null

Proposed solution: explicitly pass the site ID of the parent element into `Craft::$app->elements->getElementById()` at `BaseContentMigration::getFieldContent()` on line 103